### PR TITLE
chore: release v0.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,23 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.0.2](https://github.com/CommanderStorm/mdbook-mermaid-ssr/compare/v0.0.1...v0.0.2) - 2025-12-31
+
+### Other
+
+- *(deps)* use a faster way of installing chromium in CI  ([#7](https://github.com/CommanderStorm/mdbook-mermaid-ssr/pull/7))
+- migrate to formatted snapshots ([#5](https://github.com/CommanderStorm/mdbook-mermaid-ssr/pull/5))
+- remove unessesary packages ([#4](https://github.com/CommanderStorm/mdbook-mermaid-ssr/pull/4))
+- taiki based dependency installation ([#2](https://github.com/CommanderStorm/mdbook-mermaid-ssr/pull/2))
+- migrate xtask -> autofix ([#1](https://github.com/CommanderStorm/mdbook-mermaid-ssr/pull/1))
+- add dependabot
+- release v0.0.1
 # v0.17.0 (2025-11-18)
 
 * Update to mdbook v0.5 -- this now uses `mdbook-preprocessor`, which should make the build a bit faster

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -746,7 +746,7 @@ dependencies = [
 
 [[package]]
 name = "mdbook-mermaid-ssr"
-version = "0.0.1"
+version = "0.0.2"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mdbook-mermaid-ssr"
-version = "0.0.1"
+version = "0.0.2"
 authors = ["Frank Elsinga <frank.elsinga@tum.de>", "Jan-Erik Rediger <janerik@fnordig.de>"]
 description = "mdbook preprocessor to add mermaid support with server-side rendering"
 license = "MPL-2.0"


### PR DESCRIPTION



## 🤖 New release

* `mdbook-mermaid-ssr`: 0.0.1 -> 0.0.2 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.0.2](https://github.com/CommanderStorm/mdbook-mermaid-ssr/compare/v0.0.1...v0.0.2) - 2025-12-31

### Other

- *(deps)* use a faster way of installing chromium in CI  ([#7](https://github.com/CommanderStorm/mdbook-mermaid-ssr/pull/7))
- migrate to formatted snapshots ([#5](https://github.com/CommanderStorm/mdbook-mermaid-ssr/pull/5))
- remove unessesary packages ([#4](https://github.com/CommanderStorm/mdbook-mermaid-ssr/pull/4))
- taiki based dependency installation ([#2](https://github.com/CommanderStorm/mdbook-mermaid-ssr/pull/2))
- migrate xtask -> autofix ([#1](https://github.com/CommanderStorm/mdbook-mermaid-ssr/pull/1))
- add dependabot
- release v0.0.1
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).