### PR TITLE
chore: release v0.0.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,20 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.0.7](https://github.com/CommanderStorm/mdbook-mermaid-ssr/compare/v0.0.6...v0.0.7) - 2025-12-31
 
-### Fixed
+This release contains
 
-- *(ci)* formatting of spaces after the version in security policy ([#28](https://github.com/CommanderStorm/mdbook-mermaid-ssr/pull/28))
-
-### Other
-
-- [StepSecurity] ci: Harden GitHub Actions ([#33](https://github.com/CommanderStorm/mdbook-mermaid-ssr/pull/33))
-- chore(ci)(deps): bump github/codeql-action from 3.31.7 to 4.31.9 ([#32](https://github.com/CommanderStorm/mdbook-mermaid-ssr/pull/32))
-- *(ci)* Ci hardening ([#31](https://github.com/CommanderStorm/mdbook-mermaid-ssr/pull/31))
-- *(release)* Relax when the cd action is being run ([#29](https://github.com/CommanderStorm/mdbook-mermaid-ssr/pull/29))
+- signinficant improvements towards our suppy chain security ([#28](https://github.com/CommanderStorm/mdbook-mermaid-ssr/pull/28)) ([#31](https://github.com/CommanderStorm/mdbook-mermaid-ssr/pull/31)) ([#27](https://github.com/CommanderStorm/mdbook-mermaid-ssr/pull/27)) ([#26](https://github.com/CommanderStorm/mdbook-mermaid-ssr/pull/26))
+- another experiment how to get us to produce better binaries in releses ([#29](https://github.com/CommanderStorm/mdbook-mermaid-ssr/pull/29))
 - *(ci)* faster ci by only building in debug mode ([#30](https://github.com/CommanderStorm/mdbook-mermaid-ssr/pull/30))
 - *(deps)* bump mermaid from 11.4.1 to 11.12.2 in the npm-dependencies group ([#9](https://github.com/CommanderStorm/mdbook-mermaid-ssr/pull/9))
-- add a security policy ([#27](https://github.com/CommanderStorm/mdbook-mermaid-ssr/pull/27))
-- pin more dependencys ([#26](https://github.com/CommanderStorm/mdbook-mermaid-ssr/pull/26))
 
 ## [0.0.6](https://github.com/CommanderStorm/mdbook-mermaid-ssr/compare/v0.0.5...v0.0.6) - 2025-12-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.7](https://github.com/CommanderStorm/mdbook-mermaid-ssr/compare/v0.0.6...v0.0.7) - 2025-12-31
+
+### Fixed
+
+- *(ci)* formatting of spaces after the version in security policy ([#28](https://github.com/CommanderStorm/mdbook-mermaid-ssr/pull/28))
+
+### Other
+
+- [StepSecurity] ci: Harden GitHub Actions ([#33](https://github.com/CommanderStorm/mdbook-mermaid-ssr/pull/33))
+- chore(ci)(deps): bump github/codeql-action from 3.31.7 to 4.31.9 ([#32](https://github.com/CommanderStorm/mdbook-mermaid-ssr/pull/32))
+- *(ci)* Ci hardening ([#31](https://github.com/CommanderStorm/mdbook-mermaid-ssr/pull/31))
+- *(release)* Relax when the cd action is being run ([#29](https://github.com/CommanderStorm/mdbook-mermaid-ssr/pull/29))
+- *(ci)* faster ci by only building in debug mode ([#30](https://github.com/CommanderStorm/mdbook-mermaid-ssr/pull/30))
+- *(deps)* bump mermaid from 11.4.1 to 11.12.2 in the npm-dependencies group ([#9](https://github.com/CommanderStorm/mdbook-mermaid-ssr/pull/9))
+- add a security policy ([#27](https://github.com/CommanderStorm/mdbook-mermaid-ssr/pull/27))
+- pin more dependencys ([#26](https://github.com/CommanderStorm/mdbook-mermaid-ssr/pull/26))
+
 ## [0.0.6](https://github.com/CommanderStorm/mdbook-mermaid-ssr/compare/v0.0.5...v0.0.6) - 2025-12-31
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -746,7 +746,7 @@ dependencies = [
 
 [[package]]
 name = "mdbook-mermaid-ssr"
-version = "0.0.6"
+version = "0.0.7"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mdbook-mermaid-ssr"
-version = "0.0.6"
+version = "0.0.7"
 authors = ["Frank Elsinga <frank.elsinga@tum.de>", "Jan-Erik Rediger <janerik@fnordig.de>"]
 description = "mdbook preprocessor to add mermaid support with server-side rendering"
 license = "MPL-2.0"

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,7 +6,7 @@ We release patches for security vulnerabilities. Currently supported versions:
 
 | Version | Supported          |
 | ------- | ------------------ |
-| 0.0.6   | :white_check_mark: |
+| 0.0.7   | :white_check_mark: |
 
 ## Reporting a Vulnerability
 


### PR DESCRIPTION



## 🤖 New release

* `mdbook-mermaid-ssr`: 0.0.6 -> 0.0.7 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.0.7](https://github.com/CommanderStorm/mdbook-mermaid-ssr/compare/v0.0.6...v0.0.7) - 2025-12-31

### Fixed

- *(ci)* formatting of spaces after the version in security policy ([#28](https://github.com/CommanderStorm/mdbook-mermaid-ssr/pull/28))

### Other

- [StepSecurity] ci: Harden GitHub Actions ([#33](https://github.com/CommanderStorm/mdbook-mermaid-ssr/pull/33))
- chore(ci)(deps): bump github/codeql-action from 3.31.7 to 4.31.9 ([#32](https://github.com/CommanderStorm/mdbook-mermaid-ssr/pull/32))
- *(ci)* Ci hardening ([#31](https://github.com/CommanderStorm/mdbook-mermaid-ssr/pull/31))
- *(release)* Relax when the cd action is being run ([#29](https://github.com/CommanderStorm/mdbook-mermaid-ssr/pull/29))
- *(ci)* faster ci by only building in debug mode ([#30](https://github.com/CommanderStorm/mdbook-mermaid-ssr/pull/30))
- *(deps)* bump mermaid from 11.4.1 to 11.12.2 in the npm-dependencies group ([#9](https://github.com/CommanderStorm/mdbook-mermaid-ssr/pull/9))
- add a security policy ([#27](https://github.com/CommanderStorm/mdbook-mermaid-ssr/pull/27))
- pin more dependencys ([#26](https://github.com/CommanderStorm/mdbook-mermaid-ssr/pull/26))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).