### PR TITLE
chore: release v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.0.8](https://github.com/CommanderStorm/mdbook-mermaid-ssr/compare/v0.0.7...v0.0.8) - 2025-12-31
-
-### Fixed
-
-- fix firefox being mentioned ([#36](https://github.com/CommanderStorm/mdbook-mermaid-ssr/pull/36))
+## [0.2.0](https://github.com/CommanderStorm/mdbook-mermaid-ssr/compare/v0.0.7...v0.0.8) - 2025-12-31
+Due to a bug in our early release CI, v0.1.0 got published.
+This bumps our version to 0.2.0. Code wise, it is identical to 0.0.7, but not 0.1.0.
+DON'T use 0.1.0.
 
 ## [0.0.7](https://github.com/CommanderStorm/mdbook-mermaid-ssr/compare/v0.0.6...v0.0.7) - 2025-12-31
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -746,7 +746,7 @@ dependencies = [
 
 [[package]]
 name = "mdbook-mermaid-ssr"
-version = "0.0.8"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mdbook-mermaid-ssr"
-version = "0.0.8"
+version = "0.2.0"
 authors = ["Frank Elsinga <frank.elsinga@tum.de>", "Jan-Erik Rediger <janerik@fnordig.de>"]
 description = "mdbook preprocessor to add mermaid support with server-side rendering"
 license = "MPL-2.0"

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,7 +6,7 @@ We release patches for security vulnerabilities. Currently supported versions:
 
 | Version | Supported          |
 | ------- | ------------------ |
-| 0.0.8   | :white_check_mark: |
+| 0.2.0   | :white_check_mark: |
 
 ## Reporting a Vulnerability
 


### PR DESCRIPTION



## 🤖 New release

* `mdbook-mermaid-ssr`: 0.0.7 -> 0.0.8 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.0.8](https://github.com/CommanderStorm/mdbook-mermaid-ssr/compare/v0.0.7...v0.0.8) - 2025-12-31

### Fixed

- fix firefox being mentioned ([#36](https://github.com/CommanderStorm/mdbook-mermaid-ssr/pull/36))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).