### PR TITLE
chore: release v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.3.0](https://github.com/CommanderStorm/mdbook-mermaid-ssr/compare/v0.2.0...v0.3.0) - 2026-01-02
 
-### Other
+### Configuration
 
-- configurable timeouts and options ([#38](https://github.com/CommanderStorm/mdbook-mermaid-ssr/pull/38))
+This PR makes configuring the mermaid options, timeouts and a few other options possible.
+Please see our readme for how to do this. ([#38](https://github.com/CommanderStorm/mdbook-mermaid-ssr/pull/38))
+
+### Others
+
 - *(ci)* Bless on a PR being labeled `bless` ([#45](https://github.com/CommanderStorm/mdbook-mermaid-ssr/pull/45))
 - add a finishing job to the security workflow ([#43](https://github.com/CommanderStorm/mdbook-mermaid-ssr/pull/43))
 - gitignore all books ([#42](https://github.com/CommanderStorm/mdbook-mermaid-ssr/pull/42))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0](https://github.com/CommanderStorm/mdbook-mermaid-ssr/compare/v0.2.0...v0.3.0) - 2026-01-02
+
+### Other
+
+- configurable timeouts and options ([#38](https://github.com/CommanderStorm/mdbook-mermaid-ssr/pull/38))
+- *(ci)* Bless on a PR being labeled `bless` ([#45](https://github.com/CommanderStorm/mdbook-mermaid-ssr/pull/45))
+- add a finishing job to the security workflow ([#43](https://github.com/CommanderStorm/mdbook-mermaid-ssr/pull/43))
+- gitignore all books ([#42](https://github.com/CommanderStorm/mdbook-mermaid-ssr/pull/42))
+- make sure that cargo.toml is consistently sorted ([#39](https://github.com/CommanderStorm/mdbook-mermaid-ssr/pull/39))
+
 ## [0.2.0](https://github.com/CommanderStorm/mdbook-mermaid-ssr/compare/v0.0.7...v0.0.8) - 2025-12-31
 Due to a bug in our early release CI, v0.1.0 got published.
 This bumps our version to 0.2.0. Code wise, it is identical to 0.0.7, but not 0.1.0.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -740,7 +740,7 @@ dependencies = [
 
 [[package]]
 name = "mdbook-mermaid-ssr"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mdbook-mermaid-ssr"
-version = "0.2.0"
+version = "0.3.0"
 authors = [
     "Frank Elsinga <frank.elsinga@tum.de>",
     "Jan-Erik Rediger <janerik@fnordig.de>",

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,7 +6,7 @@ We release patches for security vulnerabilities. Currently supported versions:
 
 | Version | Supported          |
 | ------- | ------------------ |
-| 0.2.0   | :white_check_mark: |
+| 0.3.0   | :white_check_mark: |
 
 ## Reporting a Vulnerability
 


### PR DESCRIPTION



## 🤖 New release

* `mdbook-mermaid-ssr`: 0.2.0 -> 0.3.0 (⚠ API breaking changes)

### ⚠ `mdbook-mermaid-ssr` breaking changes

```text
--- failure method_parameter_count_changed: pub method parameter count changed ---

Description:
A publicly-visible method now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.45.0/src/lints/method_parameter_count_changed.ron

Failed in:
  mdbook_mermaid_ssr::Mermaid::new now takes 1 parameters instead of 0, in /tmp/.tmp7jOx2x/mdbook-mermaid-ssr/src/lib.rs:21
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.3.0](https://github.com/CommanderStorm/mdbook-mermaid-ssr/compare/v0.2.0...v0.3.0) - 2026-01-02

### Other

- configurable timeouts and options ([#38](https://github.com/CommanderStorm/mdbook-mermaid-ssr/pull/38))
- *(ci)* Bless on a PR being labeled `bless` ([#45](https://github.com/CommanderStorm/mdbook-mermaid-ssr/pull/45))
- add a finishing job to the security workflow ([#43](https://github.com/CommanderStorm/mdbook-mermaid-ssr/pull/43))
- gitignore all books ([#42](https://github.com/CommanderStorm/mdbook-mermaid-ssr/pull/42))
- make sure that cargo.toml is consistently sorted ([#39](https://github.com/CommanderStorm/mdbook-mermaid-ssr/pull/39))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).